### PR TITLE
locker lockId added to exception message when lock failed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   ],
   "require": {
     "php": ">=7.1",
+    "ex-json": "*",
     "mtdowling/cron-expression": "1.2.*@stable",
     "psr/log":"1.0.*@stable"
   },

--- a/src/Daemon.php
+++ b/src/Daemon.php
@@ -176,8 +176,8 @@ class Daemon
         $locked = $this->locker->lock($lockId);
         if ($locked === false) {
             throw new \RuntimeException(
-                'Cron #' . $cronId . ' lock failed! LockId: ' . $lockId
-                . ($this->isDeadLock($lockId) ? " ( Deadlock found! ) " : "")
+                'Cron #' . $cronId . ' lock failed! jobName: ' . $lockId
+                . ($this->isDeadLock($lockId) ? " ( Deadlock found! ) LockId: " . $this->locker->getJobUniqId($lockId) : "")
             );
         }
         @exec($this->lastRunnedCronJob->getCmd(), $output, $retval);


### PR DESCRIPTION
Adding calculated lockId to lock failed exception message from locker can be needed to unlock manually.